### PR TITLE
Add php-intl

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -72,4 +72,4 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.apt]
-    packages = "php8.0-mbstring,php8.0-zip,php8.0-GD,php8.0-exif,php8.0-XMLWriter"
+    packages = "php8.0-mbstring,php8.0-zip,php8.0-GD,php8.0-exif,php8.0-XMLWriter,php8.0-intl"

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "ZwiiCMS"
 description.en = "Simple, lightweight, database-free, scalable and responsive CMS"
 description.fr = "CMS simple, léger, sans base de données, modulable et responsive"
 
-version = "12.3.02~ynh1"
+version = "12.3.02~ynh2"
 
 maintainers = ["ewilly"]
 


### PR DESCRIPTION
Module intl manquant - Module intl missing.

ZwiiCMS ne peut pas démarrer ; activez les extensions requises - ZwiiCMS cannot start, enabled missing extensions.

## Problem

- *Module intl manquant - Module intl missing.

ZwiiCMS ne peut pas démarrer ; activez les extensions requises - ZwiiCMS cannot start, enabled missing extensions.*

## Solution

- *Add `php8.0-intl` in the manifest*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
